### PR TITLE
Requests use location id

### DIFF
--- a/lib/GUI/create.dart
+++ b/lib/GUI/create.dart
@@ -10,11 +10,13 @@
 
 import 'dart:async';
 import 'package:ambience/constants.dart';
+import 'package:ambience/providers/location_provider.dart';
 import 'package:ambience/weatherEntry/weather_entry.dart';
 import 'package:flutter/material.dart';
 import 'dart:io';
 import "package:ambience/GUI/wallpaperobj.dart";
 import "package:ambience/handlers/file_handler.dart";
+import 'package:provider/provider.dart';
 
 void main() => runApp(
       CreateApp(
@@ -24,6 +26,8 @@ void main() => runApp(
           14,
           30,
           [false, true, false, true, false, true, false],
+          "Boston",
+          4930956,
           [],
         ),
         intention: 1,
@@ -617,7 +621,9 @@ class _CreateApp extends State<CreateApp> {
                         toMilitary(
                             toNumber(hourController.text), AMPM.getAmPm()),
                         toNumber(minuteController.text),
-                        dayToggles.getDays());
+                        dayToggles.getDays(),
+                        context.read<LocationProvider>().location!.name,
+                        context.read<LocationProvider>().location!.id);
 
                     confirmCreation(
                             widget.intention, widget.contextWallpaper, newObj)

--- a/lib/GUI/list.dart
+++ b/lib/GUI/list.dart
@@ -2,10 +2,12 @@
 // add a text widget to show the days active for a given wallpaperEntry
 
 import 'package:ambience/constants.dart';
+import 'package:ambience/providers/location_provider.dart';
 import 'package:flutter/material.dart';
 import 'dart:io';
 import 'package:ambience/weatherEntry/weather_entry.dart';
 import "package:ambience/GUI/wallpaperobj.dart";
+import 'package:provider/provider.dart';
 
 void main() => runApp(ListApp());
 
@@ -30,9 +32,9 @@ class EntryControls extends StatelessWidget {
 
     ID = id;
 
-    VoidCallback action = () {
+    action() {
       func(ID);
-    };
+    }
 
     Controls = Row(
       // displays the wallpaper's controls
@@ -40,19 +42,20 @@ class EntryControls extends StatelessWidget {
         IconButton(
           onPressed:
               action, // function to delete the wallpaperObj, deleting the rules associated with it
-          icon: Icon(Icons.delete),
+          icon: const Icon(Icons.delete),
           style: controlStyle,
         ),
         IconButton(
           onPressed:
               action, //function to edit the existing wallpaper, goes to create screen w/ data
-          icon: Icon(Icons.edit),
+          icon: const Icon(Icons.edit),
           style: controlStyle,
         ),
       ],
     );
   }
 
+  @override
   Widget build(BuildContext context) {
     return Controls;
   }
@@ -61,7 +64,7 @@ class EntryControls extends StatelessWidget {
 class WallpaperEntry extends StatelessWidget {
   int ID = 0;
 
-  WallpaperObj object = WallpaperObj();
+  WallpaperObj object = WallpaperObj(0);
 
   String wallFile = "Null";
 
@@ -216,7 +219,7 @@ class wallPapersWindowState extends State<wallPapersWindow> {
 // function that creates a list of WallpaperObjs.
 // Searches list of created WeatherEntries and groups them together
 // into a list of WallpaperObjects.
-Future<List<WallpaperObj>> listSavedWallpapers() async {
+Future<List<WallpaperObj>> listSavedWallpapers(BuildContext context) async {
   debugPrint("listSavedWallpapers called!");
 
   Map<String, WeatherEntry> rulesList = await WeatherEntry.getRuleList();
@@ -271,7 +274,9 @@ Future<List<WallpaperObj>> listSavedWallpapers() async {
 
   // second loop, creates a list of WallpaperObj based on how many unique entries there are
   for (int k = 0; k < foundWeatherEntries.length; k++) {
-    temp.add(WallpaperObj(foundWeatherEntries[k]));
+    // I know, time though
+    temp.add(WallpaperObj(
+        context.read<LocationProvider>().location!.id, foundWeatherEntries[k]));
   }
 
   if (temp.isEmpty) {
@@ -293,7 +298,7 @@ class ListAppState extends State<ListApp> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: FutureBuilder<List<WallpaperObj>>(
-          future: listSavedWallpapers(),
+          future: listSavedWallpapers(context),
           builder: (BuildContext context,
               AsyncSnapshot<List<WallpaperObj>> snapshot) {
             if (!snapshot.hasData) {

--- a/lib/GUI/main screen.dart
+++ b/lib/GUI/main screen.dart
@@ -1,5 +1,4 @@
 import 'package:ambience/GUI/create.dart';
-import 'package:ambience/GUI/list.dart';
 import 'package:ambience/firebase/fire_handler.dart';
 import 'package:ambience/models/location_model.dart';
 import 'package:ambience/providers/location_provider.dart';
@@ -8,7 +7,6 @@ import "package:ambience/GUI/wallpaperobj.dart";
 import 'dart:io';
 import "dart:async";
 import "package:ambience/constants.dart";
-import 'package:flutter/services.dart';
 
 import 'package:provider/provider.dart';
 
@@ -238,7 +236,9 @@ class MainApp extends StatelessWidget {
                   context,
                   MaterialPageRoute(
                     builder: (context) => CreateApp(
-                      contextWallpaper: WallpaperObj(),
+                      contextWallpaper: WallpaperObj(
+                          context.read<LocationProvider>().location?.id ??
+                              4930956),
                       intention: 1,
                       location: getLocation(),
                     ),

--- a/lib/GUI/wallpaperobj.dart
+++ b/lib/GUI/wallpaperobj.dart
@@ -44,6 +44,7 @@ class WallpaperObj {
   WeatherCondition cond = WeatherCondition.Clear;
   String time = "";
   String city = "";
+  int cityId;
 
   // time is military, must be converted
   // in order to be shown in frontend
@@ -60,7 +61,7 @@ class WallpaperObj {
   List<bool> days = [false, false, false, false, false, false, false];
   // constructor for an existing WeatherEntry(s)
   // list MUST be in order from sunday to saturday
-  WallpaperObj([this.entries = const []]) {
+  WallpaperObj(this.cityId, [this.entries = const []]) {
     if (entries.isNotEmpty) {
       filePath = entries[0].wallpaperFilepath;
       cond = entries[0].weatherCondition;
@@ -114,18 +115,18 @@ class WallpaperObj {
   }
 
   WallpaperObj.newObj(
-      this.filePath, this.cond, this.hour, this.minute, this.days,
+      this.filePath, this.cond, this.hour, this.minute, this.days, this.city, this.cityId,
       [this.entries = const []]) {
-    time = hour.toString() + ":" + minute.toString();
+    time = "$hour:$minute";
 
-    entries = createEntries(filePath, cond, hour, minute, days, city);
+    entries = createEntries(filePath, cond, hour, minute, days, city, cityId);
 
     days = [false, false, false, false, false, false, false];
   }
 
   //private function to create entries out of data received
   List<WeatherEntry> createEntries(String file, WeatherCondition cond, int hour,
-      int minute, List<bool> days, String city) {
+      int minute, List<bool> days, String city, int cityId) {
     List<WeatherEntry> temp = [];
 
     for (int i = 0; i < days.length; i++) {
@@ -134,7 +135,7 @@ class WallpaperObj {
 
         TimeOfDay tempTime = TimeOfDay(hour: hour, minute: minute);
 
-        temp.add(WeatherEntry(tempTime, DayOfWeek.values[i], file, cond, city));
+        temp.add(WeatherEntry(tempTime, DayOfWeek.values[i], file, cond, city, cityId));
       }
     }
 

--- a/lib/api/weather.dart
+++ b/lib/api/weather.dart
@@ -1,12 +1,12 @@
+import 'package:ambience/models/location_model.dart';
 import 'weather_api.dart';
 import 'package:flutter/foundation.dart';
 import 'package:ambience/storage/storage.dart';
 import 'dart:developer';
-import 'package:ambience/handlers/request_handler.dart';
 import 'dart:convert';
 
 //Reads weather data JSON from file.
-Future<void> weatherForecast(String? input) async {
+Future<void> weatherForecast(LocationModel? input) async {
   //get weather data
   if (await (getAndWriteWeatherForecast(input)) == false) {
     debugPrint("Failed to get Weatherdata!");
@@ -21,15 +21,14 @@ Future<void> weatherForecast(String? input) async {
   inspect(weatherData);
 }
 
-Future<Map<String, dynamic>> weatherNow(String? input) async {
+Future<Map<String, dynamic>> weatherNow(LocationModel? input) async {
   //get weather data
-
   try {
     var nowWeather = await (getWeatherNow(input));
     return jsonDecode(nowWeather);
   } catch (e) {
     debugPrint(e.toString());
-    Map<String, dynamic> empty = <String,dynamic>{};
+    Map<String, dynamic> empty = <String, dynamic>{};
     return empty;
   }
 }

--- a/lib/api/weather_api.dart
+++ b/lib/api/weather_api.dart
@@ -1,42 +1,27 @@
+import 'package:ambience/models/location_model.dart';
 import 'package:ambience/storage/storage.dart';
-import 'geolocate_api.dart';
-import 'package:flutter/foundation.dart';
 import 'package:ambience/handlers/request_handler.dart';
-
-/* Uncomment these for using the weather model */
-// import 'dart:convert';
-// import 'package:ambience/models/weather_model.dart';
 
 //Takes cordinates from geolocate api and writes weather data JSON to file using
 //storage class.
-Future<dynamic> getWeatherForecast(String? input,
-    {List<dynamic>? latlon, Handler handler = const RequestHandler()}) async {
-  //cords = 2 size array with lat and lon, index 0 and 1 respectively
-  List<dynamic> cords = latlon ?? await geolocate(input);
-  //if name couldn't be geolocated
-  if (cords.isEmpty) {
-    debugPrint("Geolocation failed");
-    return false;
-  }
-  dynamic weatherResponse =
-      await handler.requestWeatherDataForecast(input, cords);
-  /* WeatherModel: Usage: Uncomment the // escaped lines to use the model right away */
-  /* From the json data we get from OpenWeather, we can take the list of weather info as a
-  list of dynamic */
-  // List<dynamic> respDecode = jsonDecode(weatherResponse.body)['list'];
-  /* Then, for each one of the maps inside this list (each one of the weather data snippets), we
-  can take them all and parse them from a Map<String, dynamic> (what's inside the list).
-  You can think of it as javascript's Array.map(). */
-  // List<WeatherModel> allWeatherData = respDecode.map((e) => WeatherModel.fromJson(e)).toList();
-  /* Finally, we can reference any of these weather data as we would with an element of any
-  array/list. */
-  // WeatherModel weatherData = allWeatherData[0];
-  // debugPrint(weatherData.windInfo.speed.toString());
-  //succeeded
+Future<dynamic> getWeatherForecast(LocationModel? input,
+    {Handler handler = const RequestHandler()}) async {
+  // List<dynamic> cords = latlon ?? await geolocate(input);
+  // if (cords.isEmpty) {
+  //   debugPrint("Geolocation failed");
+  //   return false;
+  // }
+  dynamic weatherResponse = await handler.requestWeatherDataForecast(input?.id);
   return weatherResponse;
 }
 
-Future<bool> getAndWriteWeatherForecast(String? input) async {
+Future<dynamic> getWeatherForecastD(int input,
+    {Handler handler = const RequestHandler()}) async {
+  dynamic weatherResponse = await handler.requestWeatherDataForecast(input);
+  return weatherResponse;
+}
+
+Future<bool> getAndWriteWeatherForecast(LocationModel? input) async {
   dynamic resp = await getWeatherForecast(input);
   if (resp == false) return false;
   Storage storage = Storage();
@@ -44,20 +29,28 @@ Future<bool> getAndWriteWeatherForecast(String? input) async {
   return true;
 }
 
-Future<bool> getWeatherNowRequest(String? input) async {
+Future<bool> getAndWriteWeatherForecastD(int input) async {
+  dynamic resp = await getWeatherForecastD(input);
+  if (resp == false) return false;
+  Storage storage = Storage();
+  await storage.writeAppDocFile(resp.body, storage.weatherDataPath);
+  return true;
+}
+
+Future<bool> getWeatherNowRequest(LocationModel? input) async {
   dynamic resp = await getWeatherNow(input);
   if (resp == false) return false;
   return true;
 }
 
-Future<dynamic> getWeatherNow(String? input,
-    {List<dynamic>? latlon, Handler handler = const RequestHandler()}) async {
+Future<dynamic> getWeatherNow(LocationModel? input,
+    {Handler handler = const RequestHandler()}) async {
   //cords = 2 size array with lat and lon, index 0 and 1 respectively
-  List<dynamic> cords = latlon ?? await geolocate(input);
-  //if name couldn't be geolocated
-  if (cords.isEmpty) {
-    throw "failed geolocation";
-  }
-  dynamic weatherResponse = await handler.requestWeatherDataNow(input, cords);
+  // List<dynamic> cords = latlon ?? await geolocate(input);
+  // //if name couldn't be geolocated
+  // if (cords.isEmpty) {
+  //   throw "failed geolocation";
+  // }
+  dynamic weatherResponse = await handler.requestWeatherDataNow(input?.id);
   return weatherResponse.body;
 }

--- a/lib/daemon/daemon.dart
+++ b/lib/daemon/daemon.dart
@@ -238,7 +238,7 @@ class Daemon {
     //get current time, so data fetch time doesn't effect finding the most up to date weather data
     var nowTime = DateTime.now();
     //if cannot access weather api
-    if ((await getAndWriteWeatherForecast(ruleObj.city)) == false) {
+    if ((await getAndWriteWeatherForecastD(ruleObj.cityId)) == false) {
       debugPrint(
           "Cannot access online weather data, checking offline weather data. -Daemon.weathercheck");
     }

--- a/lib/handlers/request_handler.dart
+++ b/lib/handlers/request_handler.dart
@@ -5,10 +5,8 @@ import "package:flutter_dotenv/flutter_dotenv.dart";
 
 abstract class Handler {
   Future<dynamic> requestGeolocationData(String? cityName) async {}
-  Future<dynamic> requestWeatherDataForecast(
-      String? input, List<dynamic> cords) async {}
-  Future<dynamic> requestWeatherDataNow(
-      String? input, List<dynamic> cords) async {}
+  Future<dynamic> requestWeatherDataForecast(int? locationId) async {}
+  Future<dynamic> requestWeatherDataNow(int? locationId) async {}
 }
 
 class RequestHandler implements Handler {
@@ -35,21 +33,20 @@ class RequestHandler implements Handler {
   String get apiKey => _apiKey;
 
   @override
-  Future<dynamic> requestWeatherDataForecast(
-      String? input, List<dynamic> cords) async {
+  Future<dynamic> requestWeatherDataForecast(int? locationId) async {
     //api.openweathermap.org/data/2.5/forecast?lat={lat}&lon={lon}&appid={API key}
     Uri weatherUri = Uri.parse(
-        'https://api.openweathermap.org/data/2.5/forecast?lat=${cords[0]}&lon=${cords[1]}&appid=$_apiKey');
+        'https://api.openweathermap.org/data/2.5/forecast?id=$locationId&appid=$_apiKey');
     //API call to openweather, sends back a json.
     http.Response weatherResponse = await http.get(weatherUri);
     return weatherResponse;
   }
 
   @override
-  Future<dynamic> requestWeatherDataNow(String? input, List<dynamic> cords) async {
+  Future<dynamic> requestWeatherDataNow(int? locationId) async {
     //api.openweathermap.org/data/2.5/forecast?lat={lat}&lon={lon}&appid={API key}
     Uri weatherUri = Uri.parse(
-        'https://api.openweathermap.org/data/2.5/weather?lat=${cords[0]}&lon=${cords[1]}&appid=$_apiKey');
+        'https://api.openweathermap.org/data/2.5/weather?id=$locationId&appid=$_apiKey');
     //API call to openweather, sends back a json.
     http.Response weatherResponse = await http.get(weatherUri);
     return weatherResponse;

--- a/lib/providers/location_provider.dart
+++ b/lib/providers/location_provider.dart
@@ -21,11 +21,10 @@ class LocationProvider with ChangeNotifier {
       //use this when cityID code infrastructure is setup
       String cityID = "${_foundLocation!.id}";
       //use this when cityID code infrastructure is setup
-      //await WeatherEntry.updateLocInfo(cityID);
-      
+      await WeatherEntry.updateLocInfo(cityID);
+      await Utils.saveToLocationFile(_foundLocation!);
       //Using null assertion since confirmed to be non-null at this point
       //remove this once city ID system is in place, this for legacy support.
-      await WeatherEntry.updateLocInfo(_foundLocation!.name);
     }
     notifyListeners();
   }

--- a/lib/weatherEntry/weather_entry.dart
+++ b/lib/weatherEntry/weather_entry.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:ambience/storage/storage.dart';
 import 'dart:convert';
 import 'package:path/path.dart' as p;
-import 'package:ambience/providers/location_provider.dart';
 
 // added empty for when the user hasn't entered anything yet
 enum WeatherCondition {
@@ -46,9 +45,10 @@ class WeatherEntry {
   WeatherCondition weatherCondition = WeatherCondition.Clear;
   String idSchema = 'ambience_daemon_';
   String city = 'london';
+  int cityId = 4930956;
 
   WeatherEntry(this.startTime, this.dayOfWeek, this.wallpaperFilepath,
-      this.weatherCondition, this.city) {
+      this.weatherCondition, this.city, this.cityId) {
     wallpaperFilepath = p.normalize(wallpaperFilepath);
     idSchema += DateTime.now().millisecondsSinceEpoch.toString();
   }
@@ -162,6 +162,7 @@ class WeatherEntry {
     weatherCondition = WeatherCondition.values[(json['weatherCondition'])];
     idSchema = json['idSchema'];
     city = json['city'];
+    cityId = json['cityId'];
   }
 
   static Future<void> deleteRuleList() async {
@@ -185,7 +186,8 @@ class WeatherEntry {
         'wallpaperFilepath': wallpaperFilepath,
         'weatherCondition': weatherCondition.index,
         'idSchema': idSchema,
-        'city': city
+        'city': city,
+        'cityId': cityId,
       };
   bool compareWeather(String incomingWeather) {
     if (incomingWeather == weatherCondition.name) {

--- a/test/mock/mock_data.dart
+++ b/test/mock/mock_data.dart
@@ -12,6 +12,7 @@ const Map<String, dynamic> fakeCityInfo = {
   "countryCode": 207,
   'lat': 0.011,
   'lon': 1.11,
+  'id': 1843561,
 };
 
 const Map<String, dynamic> fakeGeoSingleComplete = {
@@ -31,6 +32,7 @@ Map<String, dynamic> fakeWeatherEntry = {
   "weatherCondition": WeatherCondition.Rain.index,
   "idSchema": "ambience_daemon_fakentry",
   "city": "Incheon",
+  "cityId": 1843561
 };
 
 const String mockKey = "fakepi-key";

--- a/test/unit_test.dart
+++ b/test/unit_test.dart
@@ -1,6 +1,5 @@
 import "dart:convert";
 import "dart:io" show File, Directory, FileSystemEntity;
-import "package:ambience/api/weather.dart";
 import "package:ambience/constants.dart";
 import "package:ambience/storage/storage.dart";
 import "package:ambience/weatherEntry/weather_entry.dart";
@@ -12,7 +11,6 @@ import "package:flutter_dotenv/flutter_dotenv.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:ambience/api/geolocate_api.dart";
 import "package:ambience/api/weather_api.dart";
-import "package:ambience/handlers/file_handler.dart" as FileHandler;
 import "package:ambience/handlers/request_handler.dart";
 import "package:ambience/handlers/wallpaper_handler.dart";
 import "package:ambience/models/geolocation_model.dart";
@@ -28,7 +26,7 @@ class MockRequestHandler extends Handler {
 
   @override
   Future<dynamic> requestWeatherDataForecast(
-      String? input, List<dynamic> cords) async {
+      int? locationId) async {
     return http.Response(json.encode(fakeWeatherResponse['body']), 200);
   }
 }
@@ -65,9 +63,7 @@ void main() {
   group('Weather API', () {
     test('Should return mock weather', () async {
       Handler mockHandler = MockRequestHandler();
-      List<dynamic> geo = await geolocate("Mock City", handler: mockHandler);
-      http.Response response = await getWeatherForecast("Mock City",
-          latlon: geo, handler: mockHandler);
+      http.Response response = await getWeatherForecast(fakeCityInfo['cityId'], handler: mockHandler);
       Map<String, dynamic> result = json.decode(response.body);
       expect(result, fakeWeatherResponse['body']);
     });


### PR DESCRIPTION
This branch makes use of the location id from the Location Model inside of the provider. The requests have been updated to use the location id, leaving us with no need for geolocation (in the event that we need this lat/lon data again, the weather request also returns these attributes). There are also special versions of the request functions (no function overload in Dart) used by the Daemon(s) which implement the city id inside of the weatherentry. The weather entry has been updated to save with the city name and city id, for simplicity. Tests have been updated, and I tried ```flutter test``` locally without any issues.